### PR TITLE
Remove usage of channels

### DIFF
--- a/src/DeadManSwitch.Tests/TestsForDeadManSwitchRunner.cs
+++ b/src/DeadManSwitch.Tests/TestsForDeadManSwitchRunner.cs
@@ -450,7 +450,7 @@ namespace DeadManSwitch.Tests
                 // Assert
                 result.Should().Be(Math.PI);
                 _sessionFactory.Session.Should().NotBeNull();
-                var notifications = await _sessionFactory.Session.DeadManSwitchContext.GetNotificationsAsync(cts.Token).ConfigureAwait(false);
+                var notifications = _sessionFactory.Session.DeadManSwitchContext.GetNotifications();
                 string[] expected =
                 {
                     "Notification 2",
@@ -477,7 +477,7 @@ namespace DeadManSwitch.Tests
                             var sendNotifications = Enumerable.Range(0, numberOfNotifications)
                                 .AsParallel()
                                 .WithDegreeOfParallelism(100)
-                                .Select(i => deadManSwitch.NotifyAsync("Notification " + i, cancellationToken).AsTask());
+                                .Select(i => Task.Run(() => deadManSwitch.Notify("Notification " + i)));
                             await Task.WhenAll(sendNotifications).ConfigureAwait(false);
                         }
                     ),
@@ -490,7 +490,7 @@ namespace DeadManSwitch.Tests
                 // Assert
                 result.Should().Be(Math.PI);
                 _sessionFactory.Session.Should().NotBeNull();
-                var notifications = await _sessionFactory.Session.DeadManSwitchContext.GetNotificationsAsync(cts.Token).ConfigureAwait(false);
+                var notifications = _sessionFactory.Session.DeadManSwitchContext.GetNotifications();
                 notifications.Should().HaveCount(3);
             }
         }
@@ -548,7 +548,7 @@ namespace DeadManSwitch.Tests
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Notify(string notification)
         {
-            return async (deadManSwitch, cancellationToken) => { await deadManSwitch.NotifyAsync(notification, cancellationToken).ConfigureAwait(false); };
+            return (deadManSwitch, cancellationToken) => Task.Run(() => deadManSwitch.Notify(notification));
         }
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Sleep(TimeSpan duration)
@@ -567,12 +567,12 @@ namespace DeadManSwitch.Tests
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Pause()
         {
-            return (deadManSwitch, cancellationToken) => deadManSwitch.SuspendAsync(cancellationToken).AsTask();
+            return (deadManSwitch, cancellationToken) => Task.Run(() => deadManSwitch.Suspend());
         }
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Resume()
         {
-            return (deadManSwitch, cancellationToken) => deadManSwitch.ResumeAsync(cancellationToken).AsTask();
+            return (deadManSwitch, cancellationToken) => Task.Run(() => deadManSwitch.Resume());
         }
 
         #endregion

--- a/src/DeadManSwitch.Tests/TestsForInfiniteDeadManSwitchRunner.cs
+++ b/src/DeadManSwitch.Tests/TestsForInfiniteDeadManSwitchRunner.cs
@@ -325,7 +325,7 @@ namespace DeadManSwitch.Tests
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Notify(string notification)
         {
-            return async (deadManSwitch, cancellationToken) => { await deadManSwitch.NotifyAsync(notification, cancellationToken).ConfigureAwait(false); };
+            return (deadManSwitch, cancellationToken) => Task.Run(() => deadManSwitch.Notify(notification));
         }
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Sleep(TimeSpan duration)
@@ -344,12 +344,12 @@ namespace DeadManSwitch.Tests
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Pause()
         {
-            return (deadManSwitch, cancellationToken) => deadManSwitch.SuspendAsync(cancellationToken).AsTask();
+            return (deadManSwitch, cancellationToken) => Task.Run(() => deadManSwitch.Suspend());
         }
 
         private static Func<IDeadManSwitch, CancellationToken, Task> Resume()
         {
-            return (deadManSwitch, cancellationToken) => deadManSwitch.ResumeAsync(cancellationToken).AsTask();
+            return (deadManSwitch, cancellationToken) => Task.Run(() => deadManSwitch.Resume());
         }
 
         #endregion

--- a/src/DeadManSwitch/DeadManSwitch.cs
+++ b/src/DeadManSwitch/DeadManSwitch.cs
@@ -21,23 +21,17 @@ namespace DeadManSwitch
         /// A notification message that will be shown when the worker worker is cancelled.
         /// This can be useful to retrace the last steps of the worker worker.
         /// </param>
-        /// <param name="cancellationToken">A cancellation token that will cancel the notification</param>
-        /// <returns>A <see cref="ValueTask"/></returns>
-        ValueTask NotifyAsync(string notification, CancellationToken cancellationToken = default);
+        void Notify(string notification);
 
         /// <summary>
         /// Pauses the dead man's switch. The worker worker cannot be cancelled until the dead man's switch is resumed.
         /// </summary>
-        ///<param name="cancellationToken">A cancellation token that will cancel the suspension of the dead man's switch</param>
-        /// <returns>A <see cref="ValueTask"/></returns>
-        ValueTask SuspendAsync(CancellationToken cancellationToken = default);
+        void Suspend();
 
         /// <summary>
         /// Resumes the dead man's switch after pausing it.
         /// </summary>
-        ///<param name="cancellationToken">A cancellation token that will cancel the resumption of the dead man's switch</param>
-        /// <returns>A <see cref="ValueTask"/></returns>
-        ValueTask ResumeAsync(CancellationToken cancellationToken = default);
+        void Resume();
     }
 
     /// <inheritdoc />
@@ -59,33 +53,29 @@ namespace DeadManSwitch
         }
 
         /// <inheritdoc />
-        public async ValueTask NotifyAsync(string notification, CancellationToken cancellationToken = default)
+        public void Notify(string notification)
         {
             if (notification == null) throw new ArgumentNullException(nameof(notification));
 
             _logger.Debug("The dead man's switch received a notification: {Notification}", notification);
-            
-            var enqueueStatus = _context.EnqueueStatusAsync(DeadManSwitchStatus.NotificationReceived, cancellationToken);
-            var addNotification = _context.AddNotificationAsync(new DeadManSwitchNotification(notification), cancellationToken);
 
-            await enqueueStatus.ConfigureAwait(false);
-            await addNotification.ConfigureAwait(false);
+            _context.AddNotification(new DeadManSwitchNotification(notification));
         }
 
         /// <inheritdoc />
-        public ValueTask SuspendAsync(CancellationToken cancellationToken = default)
+        public void Suspend()
         {
             _logger.Debug("The dead man's switch received a 'suspend' call");
 
-            return _context.EnqueueStatusAsync(DeadManSwitchStatus.Suspended, cancellationToken);
+            _context.Suspend();
         }
 
         /// <inheritdoc />
-        public ValueTask ResumeAsync(CancellationToken cancellationToken = default)
+        public void Resume()
         {
             _logger.Debug("The dead man's switch received a 'resume' call");
 
-            return _context.EnqueueStatusAsync(DeadManSwitchStatus.Resumed, cancellationToken);
+            _context.Resume();
         }
     }
 }

--- a/src/DeadManSwitch/InfiniteDeadManSwitchRunner.cs
+++ b/src/DeadManSwitch/InfiniteDeadManSwitchRunner.cs
@@ -81,7 +81,7 @@ namespace DeadManSwitch
 
                             _logger.Debug("Worker {WorkerName} completed gracefully", worker.Name);
 
-                            await deadManSwitch.NotifyAsync("Worker task completed gracefully", CancellationToken.None).ConfigureAwait(false);
+                            deadManSwitch.Notify("Worker task completed gracefully");
                         }
                         catch (OperationCanceledException)
                         {
@@ -90,7 +90,7 @@ namespace DeadManSwitch
                             // Restart watcher
                             await watcherTask.ConfigureAwait(false);
 
-                            await deadManSwitch.NotifyAsync("Worker task was canceled", CancellationToken.None).ConfigureAwait(false);
+                            deadManSwitch.Notify("Worker task was canceled");
 
                             watcherTask = Task.Factory.StartNew(() => deadManSwitchWatcher.WatchAsync(watcherCTS.Token), CancellationToken.None, TaskCreationOptions.LongRunning,
                                 TaskScheduler.Default);

--- a/src/DeadManSwitch/Internal/DeadManSwitchTriggerer.cs
+++ b/src/DeadManSwitch/Internal/DeadManSwitchTriggerer.cs
@@ -8,7 +8,7 @@ namespace DeadManSwitch.Internal
 {
     internal interface IDeadManSwitchTriggerer
     {
-        ValueTask TriggerAsync(CancellationToken cancellationToken);
+        void Trigger();
     }
 
     internal sealed class DeadManSwitchTriggerer : IDeadManSwitchTriggerer
@@ -24,12 +24,12 @@ namespace DeadManSwitch.Internal
             _logger = logger;
         }
 
-        public async ValueTask TriggerAsync(CancellationToken cancellationToken)
+        public void Trigger()
         {
             _logger.Warning("The worker task did not notify the dead man's switch within the agreed timeout of {TimeoutInSeconds}s " +
                             "and will be cancelled.", _deadManSwitchOptions.Timeout.TotalSeconds);
 
-            var notifications = (await _deadManSwitchContext.GetNotificationsAsync(cancellationToken).ConfigureAwait(false)).ToList();
+            var notifications = _deadManSwitchContext.GetNotifications();
 
             _logger.Warning("These were the last {NotificationCount} notifications: ", notifications.Count);
 

--- a/src/DeadManSwitch/Internal/DeadManSwitchWatcher.cs
+++ b/src/DeadManSwitch/Internal/DeadManSwitchWatcher.cs
@@ -40,12 +40,11 @@ namespace DeadManSwitch.Internal
 
             while (!cancellationToken.IsCancellationRequested)
             {
-                // TODO: IsSuspended
                 TimeSpan timeSinceLastNotification;
 
                 if (!_context.IsSuspended)
                 {
-                    timeSinceLastNotification = TimeSpan.FromTicks(DateTimeOffset.UtcNow.UtcTicks - _context.LastNotifiedTicks); ;
+                    timeSinceLastNotification = TimeSpan.FromTicks(DateTime.UtcNow.Ticks - _context.LastNotifiedTicks); ;
 
                     if (timeSinceLastNotification > _options.Timeout)
                     {

--- a/src/DeadManSwitch/Internal/DeadManSwitchWatcher.cs
+++ b/src/DeadManSwitch/Internal/DeadManSwitchWatcher.cs
@@ -7,7 +7,7 @@ namespace DeadManSwitch.Internal
 {
     internal interface IDeadManSwitchWatcher
     {
-        ValueTask WatchAsync(CancellationToken cancellationToken);
+        Task WatchAsync(CancellationToken cancellationToken);
     }
 
     internal sealed class DeadManSwitchWatcher : IDeadManSwitchWatcher
@@ -34,58 +34,36 @@ namespace DeadManSwitch.Internal
         /// You should pass this cancellation token to any worker that must be cancelled.
         /// </summary>
         /// <returns>A value indicating whether the dead man's switch triggered or not</returns>
-        public async ValueTask WatchAsync(CancellationToken cancellationToken)
+        public async Task WatchAsync(CancellationToken cancellationToken)
         {
             _logger.Debug("Watching dead man's switch");
 
-            var status = DeadManSwitchStatus.NotificationReceived;
-
             while (!cancellationToken.IsCancellationRequested)
             {
-                if (status == DeadManSwitchStatus.Suspended)
+                // TODO: IsSuspended
+                TimeSpan timeSinceLastNotification;
+
+                if (!_context.IsSuspended)
+                {
+                    timeSinceLastNotification = TimeSpan.FromTicks(DateTimeOffset.UtcNow.UtcTicks - _context.LastNotifiedTicks); ;
+
+                    if (timeSinceLastNotification > _options.Timeout)
+                    {
+                        _deadManSwitchTriggerer.Trigger();
+                        return;
+                    }
+                } 
+                else
                 {
                     _logger.Debug("The dead man's switch is suspended. The worker will not be cancelled until the dead man's switch is resumed");
 
-                    // ignore any notifications and wait until the switch goes through the 'Resumed' status
-                    while (status != DeadManSwitchStatus.Resumed)
-                    {
-                        try
-                        {
-                            status = await _context.DequeueStatusAsync(cancellationToken).ConfigureAwait(false);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            _logger.Debug("Dead man switch was canceled while waiting to be resumed.");
-                            return;
-                        }
-                    }
-
-                    _logger.Debug("The dead man's switch is now resuming.");
+                    timeSinceLastNotification = TimeSpan.Zero;
                 }
 
-                using (var timeoutCTS = new CancellationTokenSource(_options.Timeout))
-                using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCTS.Token))
-                {
-                    try
-                    {
-                        status = await _context.DequeueStatusAsync(cts.Token).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        if (cancellationToken.IsCancellationRequested)
-                        {
-                            _logger.Debug("Dead man switch watcher was canceled while waiting for the next notification");
-                            return;
-                        }
+                var timeRemaining = _options.Timeout - timeSinceLastNotification;
 
-                        if (timeoutCTS.IsCancellationRequested)
-                        {
-                            await _deadManSwitchTriggerer.TriggerAsync(cancellationToken).ConfigureAwait(false);
-
-                            return;
-                        }
-                    }
-                }
+                await Task.Delay(timeRemaining, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             _logger.Debug("Dead man switch watcher was canceled");


### PR DESCRIPTION
Resolves #13.  Includes API-breaking changes.

As mentioned in the linked issue, the usage of channels is unnecessary because there are simpler concurrency primitives that effectively implement the underlying operations needed for these three features:
1. Notification from worker thread that it is still working
2. Latest N notification message storage and retrieval
3. Suspension and resumption of the DeadManSwitch

# Implementation Details
## Original Implementation
Original implementation used two channels to implement these features.

Features 1 and 3 were implemented by an unbounded channel, which flowed alive notifications and suspension/resumption requests from the worker to the watcher.  These notifications were received in near-real-time by the watcher thread.  If the watcher thread did not receive any notifications from the channel within the timeout threshold, the DeadManSwitch would be triggered.

Feature 2 was implemented by a bounded channel, which queued the notification messages from the worker thread while dropping the oldest message(s) to make room for the new ones.  The messages were fetched from the channel by receiving all available messages from the channel.

## New Implementation
This updated implementation uses a combination of atomic (lockless) reads and writes, basic locking, and a ring buffer to implement these features.

Feature 1 is implemented by reading and writing a `long` value that represents a UTC timestamp's number of ticks.  To atomically read a `long` value, `Interlocked.Read(ref long)` and `Interlocked.Exchange(ref long, long)` are used.  When a worker thread notifies the DeadManSwitch it is still alive, the current UTC timestamp's ticks value will be stored in the `_lastNotifiedTicks` member.  Approximately every timeout threshold amount of time, the watcher will wake up from sleeping and check the `_lastNotifiedTicks` value.  If the value is greater than the threshold's value in the past, the DeadManSwitch will be triggered; otherwise the watcher will go to sleep until the current time is equal to the `_lastNotifiedTicks` timestamp plus the threshold timespan. 

Feature 2 is implemented using a fixed-size array, a index value that points to the next write location of the array, and a basic syncroot lock.  When `AddNotification` is called, the syncroot for the array is locked, the item at the `_notificationsNextItemIndex` is set to the current notification, the `_notificationsNextItemIndex` is incremented modulo the array length, and the lock is released.  The lock is necessary to prevent race conditions from double-setting items at the same location, double-incrementing the index which would skip array slots, or corrupting the coupled state of `_notifications` and `_notificationsNextItemIndex` during `GetNotifications`.

Feature 3 is implemented using a volatile bool field that is intrinsically written and read from atomically.  Before the watcher checks the `_lastNotifiedTicks` value, it will first verify that it is currently not suspended.  If it is suspended, it will cause the watcher to sleep for a full threshold timespan.  A full threshold timespan can be used because a `Resume` call will also be treated as a `Notify` call that has no message.


# Public API Changes
The `IDeadManSwitch` public API was modified to remove the need for async-await and Tasks since the underlying calls are no longer async.