### PR TITLE
Add .NET 8/9/10 multi-targeting and update NuGet packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,39 +10,32 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ windows-latest, ubuntu-latest ]
+    runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Restore NuGet packages
-        run: nuget restore ./src/DeadManSwitch.sln
-        if: matrix.os == 'windows-latest'
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.x
+            9.x
+            10.x
 
-      - name: Build DeadManSwitch
-        run: dotnet build ./src/DeadManSwitch/DeadManSwitch.csproj --configuration Release
+      - name: Restore
+        run: dotnet restore ./src/DeadManSwitch.sln
 
-      - name: Build DeadManSwitch.AspNetCore
-        run: dotnet build ./src/DeadManSwitch.AspNetCore/DeadManSwitch.AspNetCore.csproj --configuration Release
+      - name: Build
+        run: dotnet build ./src/DeadManSwitch.sln --no-restore --configuration Release
 
-      - name: Build DeadManSwitch.Examples.AspNetCore
-        run: dotnet build ./src/DeadManSwitch.Examples.AspNetCore/DeadManSwitch.Examples.AspNetCore.csproj --configuration Release
+      - name: Test (net8.0 with coverage)
+        run: dotnet test ./src/DeadManSwitch.sln --no-restore --no-build --configuration Release --framework net8.0 --collect:"XPlat Code Coverage" --settings ./src/coverlet.runsettings
 
-      - name: Build DeadManSwitch.Examples.AspNetFramework
-        run: dotnet build ./src/DeadManSwitch.Examples.AspNetFramework/DeadManSwitch.Examples.AspNetFramework.csproj --configuration Release
-        if: matrix.os == 'windows-latest'
+      - name: Test (net9.0)
+        run: dotnet test ./src/DeadManSwitch.sln --no-restore --no-build --configuration Release --framework net9.0
 
-      - name: Run DeadManSwitch.Tests on .NET Core
-        run: dotnet test ./src/DeadManSwitch.Tests/DeadManSwitch.Tests.csproj --configuration Release --framework net7.0 --collect:"XPlat Code Coverage" --settings ./src/coverlet.runsettings
+      - name: Test (net10.0)
+        run: dotnet test ./src/DeadManSwitch.sln --no-restore --no-build --configuration Release --framework net10.0
 
-      - name: Run DeadManSwitch.Tests on .NET Framework
-        run: dotnet test ./src/DeadManSwitch.Tests/DeadManSwitch.Tests.csproj --configuration Release --framework net48
-        if: matrix.os == 'windows-latest'
-
-      - name: Run DeadManSwitch.AspNetCore.Tests
-        run: dotnet test ./src/DeadManSwitch.AspNetCore.Tests/DeadManSwitch.AspNetCore.Tests.csproj --configuration Release --framework net7.0 --collect:"XPlat Code Coverage" --settings ./src/coverlet.runsettings
-
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@v4

--- a/README.MD
+++ b/README.MD
@@ -112,8 +112,7 @@ public static class ExampleInfiniteProgram
 
 For more examples, including ones that use dependency injection and allow you to hook into the logging infrastructure, see the following links:
 
-- [Examples for .NET Core](https://github.com/amoerie/dead-man-switch/tree/main/src/DeadManSwitch.Examples.AspNetCore)
-- [Examples for .NET Framework](https://github.com/amoerie/dead-man-switch/tree/main/src/DeadManSwitch.Examples.AspNetFramework)
+- [Examples for ASP.NET Core](https://github.com/amoerie/dead-man-switch/tree/main/src/DeadManSwitch.Examples.AspNetCore)
 
 # NuGet
 

--- a/src/DeadManSwitch.AspNetCore.Tests/DeadManSwitch.AspNetCore.Tests.csproj
+++ b/src/DeadManSwitch.AspNetCore.Tests/DeadManSwitch.AspNetCore.Tests.csproj
@@ -1,25 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.28.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/DeadManSwitch.AspNetCore/DeadManSwitch.AspNetCore.csproj
+++ b/src/DeadManSwitch.AspNetCore/DeadManSwitch.AspNetCore.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Title>Dead Man's Switch ASP.NET Core integration</Title>
     <Authors>Alexander Moerman</Authors>
     <PackageProjectUrl>https://github.com/amoerie/dead-man-switch</PackageProjectUrl>
     <RepositoryUrl>https://github.com/amoerie/dead-man-switch</RepositoryUrl>
     <RepositoryType>GIT</RepositoryType>
     <Version>1.0.1</Version>
-    <DocumentationFile>bin\$(Configuration)\DeadManSwitch.AspNetCore.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\DeadManSwitch.AspNetCore.xml</DocumentationFile>
     <RootNamespace>DeadManSwitch.AspNetCore</RootNamespace>
     <Description>Integration with ASP.NET core logging and dependency injection for the dead man's switch</Description>
     <Copyright>MIT</Copyright>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DeadManSwitch.Benchmarks/DeadManSwitch.Benchmarks.csproj
+++ b/src/DeadManSwitch.Benchmarks/DeadManSwitch.Benchmarks.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DeadManSwitch.Examples.AspNetCore/DeadManSwitch.Examples.AspNetCore.csproj
+++ b/src/DeadManSwitch.Examples.AspNetCore/DeadManSwitch.Examples.AspNetCore.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <LangVersion>Latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DeadManSwitch.Tests/DeadManSwitch.Tests.csproj
+++ b/src/DeadManSwitch.Tests/DeadManSwitch.Tests.csproj
@@ -1,24 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net48</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0">
+    <PackageReference Include="coverlet.collector" Version="8.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="FluentAssertions.Analyzers" Version="0.28.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="7.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.XUnit" Version="3.0.5" />
-    <PackageReference Include="xunit" Version="2.5.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/DeadManSwitch.sln
+++ b/src/DeadManSwitch.sln
@@ -23,8 +23,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadManSwitch.AspNetCore", "DeadManSwitch.AspNetCore\DeadManSwitch.AspNetCore.csproj", "{C2DB0E70-9775-4FBB-AD6D-119F5E5D9AB9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadManSwitch.Examples.AspNetFramework", "DeadManSwitch.Examples.AspNetFramework\DeadManSwitch.Examples.AspNetFramework.csproj", "{56DB1403-B120-4740-8550-A51A450B9AAA}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadManSwitch.Benchmarks", "DeadManSwitch.Benchmarks\DeadManSwitch.Benchmarks.csproj", "{43B14B3B-78C1-4703-9D1E-6ACEFA5BAC67}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeadManSwitch.AspNetCore.Tests", "DeadManSwitch.AspNetCore.Tests\DeadManSwitch.AspNetCore.Tests.csproj", "{63B51115-639A-4E4A-978B-74044467B958}"
@@ -51,10 +49,6 @@ Global
 		{C2DB0E70-9775-4FBB-AD6D-119F5E5D9AB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2DB0E70-9775-4FBB-AD6D-119F5E5D9AB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C2DB0E70-9775-4FBB-AD6D-119F5E5D9AB9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{56DB1403-B120-4740-8550-A51A450B9AAA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{56DB1403-B120-4740-8550-A51A450B9AAA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{56DB1403-B120-4740-8550-A51A450B9AAA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{56DB1403-B120-4740-8550-A51A450B9AAA}.Release|Any CPU.Build.0 = Release|Any CPU
 		{43B14B3B-78C1-4703-9D1E-6ACEFA5BAC67}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{43B14B3B-78C1-4703-9D1E-6ACEFA5BAC67}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43B14B3B-78C1-4703-9D1E-6ACEFA5BAC67}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/DeadManSwitch/DeadManSwitch.csproj
+++ b/src/DeadManSwitch/DeadManSwitch.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <Title>Dead Man's Switch</Title>
     <Authors>Alexander Moerman</Authors>
     <PackageProjectUrl>https://github.com/amoerie/dead-man-switch</PackageProjectUrl>
     <RepositoryUrl>https://github.com/amoerie/dead-man-switch</RepositoryUrl>
     <RepositoryType>GIT</RepositoryType>
     <Version>1.0.1</Version>
-    <DocumentationFile>bin\$(Configuration)\DeadManSwitch.xml</DocumentationFile>
+    <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\DeadManSwitch.xml</DocumentationFile>
     <RootNamespace>DeadManSwitch</RootNamespace>
     <Description>A dead man's switch is designed to detect a worker task that is no longer making progress and cancel it. It does this by cancelling a CancellationToken that is provided to the worker from the start. In turn, the process is responsible for notifying the dead man's switch in a periodic fashion to prevent its own cancellation.</Description>
     <Copyright>MIT</Copyright>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>latest</LangVersion>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <Configurations>Debug;Release</Configurations>
-    <OutputPath>bin\$(Configuration)\</OutputPath>
-    <AnalysisLevel>5</AnalysisLevel>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <AnalysisLevel>latest</AnalysisLevel>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
﻿## Changes

- Cross-compile library projects to .NET 8, .NET 9 and .NET 10 instead of .NET Standard 2.0
- Update all test projects to target net8.0;net9.0;net10.0
- Remove .NET Framework example project from the solution
- Update all NuGet packages to their latest versions
- Switch CI from windows-latest to ubuntu-latest (no .NET Framework targets remain)
- Collect code coverage for net8.0 only to avoid Codecov dilution from multiple TFM reports
- Remove .NET Framework example link from README.MD