### PR TITLE
Add GitHub Actions to dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: monthly
   open-pull-requests-limit: 10
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 10


### PR DESCRIPTION
## Summary
- Adds a `github-actions` ecosystem entry to `dependabot.yml` so Dependabot will open PRs when new versions of actions used in `.github/workflows/` are released (e.g. `actions/checkout`, `codecov/codecov-action`)
